### PR TITLE
Spree edge - @product has not loaded before can_show_product fires

### DIFF
--- a/app/controllers/products_controller_decorator.rb
+++ b/app/controllers/products_controller_decorator.rb
@@ -3,9 +3,10 @@ ProductsController.class_eval do
 
   private
   def can_show_product
-   if @product.stores.empty? || @product.stores.include?(@site)
-     render :file => "public/404.html", :status => 404
-   end
+    @product ||= Product.find_by_permalink!(params[:id])
+    if @product.stores.empty? || @product.stores.include?(@site)
+      render :file => "public/404.html", :status => 404
+    end
   end
 
 end


### PR DESCRIPTION
In a basic edge setup I recived the error "Error: undefined method `stores' for nil:NilClass" when trying to view a product page.

The issue is that @product has not been loaded when the can_show_product before_filter runs.
