### PR TITLE
Fix return type of #get_taxonomies

### DIFF
--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -62,7 +62,7 @@ module SpreeMultiDomain
 
         def get_taxonomies
           @taxonomies ||= current_store.present? ? Spree::Taxonomy.where(["store_id = ?", current_store.id]) : Spree::Taxonomy
-          @taxonomies = @taxonomies.find(:all, :include => {:root => :children})
+          @taxonomies = @taxonomies.includes(:root => :children)
           @taxonomies
         end
         


### PR DESCRIPTION
spree_core returns an ActiveRecord::Relation for get_taxonomies.  This plugin
modifies the return type to be an Array, because ActiveRecord::Base#find returns
an array.

This patch makes the return type continue to be an ActiveRecord::Relation, so
that (among other things) you can call the method twice without it blowing up.
