### PR TITLE
Make store_id attr_accessible in Taxonomy

### DIFF
--- a/app/models/spree/taxonomy_decorator.rb
+++ b/app/models/spree/taxonomy_decorator.rb
@@ -1,3 +1,4 @@
 Spree::Taxonomy.class_eval do
   belongs_to :store
+  attr_accessible :store_id
 end


### PR DESCRIPTION
Either we need to do this or update the taxonomy controller to be able to set it, because with spree multi domain on you can't edit taxonomies: "Can't mass-assign protected attributes: store_id"
