### PR TITLE
Make store_id not attr_accessible for security.

### DIFF
--- a/app/models/spree/taxonomy_decorator.rb
+++ b/app/models/spree/taxonomy_decorator.rb
@@ -1,4 +1,3 @@
 Spree::Taxonomy.class_eval do
   belongs_to :store
-  attr_accessible :store_id
 end


### PR DESCRIPTION
This should be set in the controller, no?
