### PR TITLE
Use Rails.env instead of depricated ENV['RAILS_ENV'] constant

### DIFF
--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -2,6 +2,6 @@ Spree::Tracker.class_eval do
   belongs_to :store
 
   def self.current(domain)
-    Spree::Tracker.where(:active => true, :environment => ENV['RAILS_ENV']).joins(:store).where("spree_stores.domains LIKE '%#{domain}%'").first
+    Spree::Tracker.where(:active => true, :environment => Rails.env).joins(:store).where("spree_stores.domains LIKE '%#{domain}%'").first
   end
 end


### PR DESCRIPTION
ENV['RAILS_ENV'] isn't as reliable as Rail.env which is preferred anyway.
