### PR TITLE
Include MultiDomainHelpers in ApplicationController so they're available when Devise renders views

### DIFF
--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -10,7 +10,7 @@ module SpreeMultiDomain
       end
 
       Spree::Config.searcher_class = Spree::Search::MultiDomain
-      Spree::BaseController.send :include, SpreeMultiDomain::MultiDomainHelpers
+      ApplicationController.send :include, SpreeMultiDomain::MultiDomainHelpers
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
This change fixed spree/spree-multi-domain#22 for me.
