### PR TITLE
Restrict SpreeMultiDomain::MultiDomainHelpers to just Spree controllers

### DIFF
--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -10,8 +10,13 @@ module SpreeMultiDomain
       end
 
       Spree::Config.searcher_class = Spree::Search::MultiDomain
-# dhw      ApplicationController.send :include, SpreeMultiDomain::MultiDomainHelpers
+      # Add the store logic to *just* the spree controllers
       Spree::BaseController.send :include, SpreeMultiDomain::MultiDomainHelpers
+
+      #if this is v1.2 and we're using spree_auth_devise, add it to a couple of others
+      # that don't inherit from Spree::BaseController
+      Spree::UserSessionsController.send  :include, SpreeMultiDomain::MultiDomainHelpers  unless Spree::UserSessionsController.is_a? Spree::BaseController
+      Spree::UserRegistrationsController.send  :include, SpreeMultiDomain::MultiDomainHelpers  unless Spree::UserSessionsController.is_a? Spree::BaseController
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
When using ActiveAdmin with an application that integrates Spree with other functions, ActiveAdmin has a problem with Fixnum params that it does't know about which were injected by:

_multi_domain_helpers.rb_ line 7:
`receiver.send :before_filter, :add_current_store_id_to_params`

The error details are:

```
RuntimeError in Admin/schools#index

Showing 
 *rvmpath*/activeadmin-0.5.0/app/views/active_admin/resource/index.html.arb 
 where line #1 raised:

I don't know what to do with Fixnum params: 3
Extracted source (around line #1):

1: insert_tag renderer_for(:index)
Rails.root: /home/dwilkins/source/Mayhem

Application Trace | Framework Trace | Full Trace
app/controllers/application_controller.rb:112:in `track_interaction'
Request

Parameters:

{"current_store_id"=>3,
 "order"=>"id_desc"}
```

Instead of injecting `SpreeMultiDomain::MultiDomainHelpers` into the ApplicationController, I injected it into _just_ the Spree controllers where it's needed.    ActiveAdmin is happy now
