### PR TITLE
add attr_accessible store_id to tracker

### DIFF
--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -1,5 +1,6 @@
 Spree::Tracker.class_eval do
   belongs_to :store
+  attr_accessible :store_id
 
   def self.current(domain)
     Spree::Tracker.where(:active => true, :environment => Rails.env).joins(:store).where("spree_stores.domains LIKE '%#{domain}%'").first


### PR DESCRIPTION
When creating a new tracker, Spree::Tracker should accept the store_id.  Otherwise it's nil.  Should probably merge with 1-2-stable too.
