### PR TITLE
Fix filter search

### DIFF
--- a/lib/spree/search/multi_domain.rb
+++ b/lib/spree/search/multi_domain.rb
@@ -9,6 +9,7 @@ module Spree::Search
       base_scope = get_products_conditions_for(base_scope, keywords) unless keywords.blank?
 
       base_scope = base_scope.on_hand unless Spree::Config[:show_zero_stock_products]
+      base_scope = add_search_scopes(base_scope)
       base_scope
     end
     


### PR DESCRIPTION
Filter search functionality is broken how in spree-multi-domain (in master and 1-3-stable branch at least), which actually apply filter parameters. Create pull request for that, it's filters as same as spree base search.
