### PR TITLE
Change url in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install Instructions
 Add to your Gemfile:
 
 ```ruby
-gem 'spree_multi_domain', git: 'git@github.com:spree/spree-multi-domain.git'
+gem 'spree_multi_domain', git: 'git://github.com/spree/spree-multi-domain.git'
 ```
 
 Then run `bundle`, and then run:


### PR DESCRIPTION
There is an exception on heroku when follow current url:

```
Host key verification failed.
       fatal: The remote end hung up unexpectedly
       Git error: command `git clone 'git@github.com:spree/spree-multi-domain.git' "/tmp/build_22565x83fshqj/vendor/bundle/ruby/1.9.1/cache/bundler/git/spree-multi-domain-71b8348f29960ac16301b990aa34f6ca5db70f04" --bare --no-hardlinks` in directory /tmp/build_22565x83fshqj has failed.
```
