### PR TITLE
Skip store validations

### DIFF
--- a/app/models/spree/store.rb
+++ b/app/models/spree/store.rb
@@ -4,7 +4,7 @@ module Spree
     has_many :taxonomies
     has_many :orders
 
-    validates_presence_of :name, :code, :domains
+    validates_presence_of :name, :code, :domains, :unless => :skip_validations
     attr_accessible :name, :code, :default, :email, :domains
 
     scope :default, where(:default => true)
@@ -17,6 +17,12 @@ module Spree
 
     def self.first_found_default
       @cached_default ||= Store.default.first
+    end
+
+    private
+    # If you want to prevent validations redefine this method to return true
+    def skip_validations
+      false
     end
   end
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -14,4 +14,17 @@ describe Spree::Store do
     by_domain.should_not include(@store2)
   end
 
+  describe '#skip_validations' do
+    let(:store_without_data) { Spree::Store.new }
+
+    context 'when returns false' do
+      it { expect(store_without_data).to_not be_valid }
+    end
+
+    context 'when returns true' do
+      before { store_without_data.stub(:skip_validations).and_return(true) }
+
+      it { store_without_data.should be_valid }
+    end
+  end
 end


### PR DESCRIPTION
I see that there is a problem in rails to clear validations in active record during class changing on `class_eval`. So, I think that it's reasonable to provide users to skip validations 
