### PR TITLE
Update PaymentMethod.available for display_on

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -3,6 +3,6 @@ Spree::Order.class_eval do
   scope :by_store, lambda { |store| where(:store_id => store.id) }
 
   def available_payment_methods
-    @available_payment_methods ||= Spree::PaymentMethod.available(store)
+    @available_payment_methods ||= Spree::PaymentMethod.available(:front_end, store)
   end
 end

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -2,9 +2,12 @@ Spree::PaymentMethod.class_eval do
   has_many :store_payment_methods
   has_many :stores, :through => :store_payment_methods
 
-  def self.available(store = nil)
+  def self.available(display_on = 'both', store = nil)
     result = all.select do |p|
-      p.active && (p.environment == Rails.env || p.environment.blank?) && (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p))
+      p.active &&
+        (p.environment == Rails.env || p.environment.blank?) &&
+        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)) &&
+        (p.display_on == display_on.to_s || p.display_on.blank?)
     end
   end
 end

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'PaymentMethod' do
   describe '.available' do
-    subject { Spree::PaymentMethod.available(store) }
+    subject { Spree::PaymentMethod.available(:front_end, store) }
 
     let!(:payment_method) { FactoryGirl.create :payment_method }
     let(:payment_method_store) { FactoryGirl.create :store, :payment_methods => [payment_method] }


### PR DESCRIPTION
This is required because of the following commit to spree:

https://github.com/spree/spree/commit/ce8f4121b08fc7420867d5909cca327d04bde12d

This added an available method which collides with the store restriction method.  This will make multi-domain play nicer with spree master.

This should be merged in to to master as well.
