### PR TITLE
Restrict shipping methods for a store.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,8 +74,8 @@ GEM
       rails (~> 3.1)
     diff-lcs (1.2.1)
     erubis (2.7.0)
-    factory_girl (4.2.0)
-      activesupport (>= 3.0.0)
+    factory_girl (2.6.4)
+      activesupport (>= 2.3.9)
     ffaker (1.12.1)
     ffi (1.4.0)
     highline (1.6.11)
@@ -212,7 +212,7 @@ PLATFORMS
 
 DEPENDENCIES
   capybara (~> 1.0.1)
-  factory_girl
+  factory_girl (~> 2.6.4)
   ffaker
   rails
   rspec-rails (~> 2.7)

--- a/app/controllers/spree/admin/stores_controller.rb
+++ b/app/controllers/spree/admin/stores_controller.rb
@@ -1,9 +1,14 @@
 class Spree::Admin::StoresController < Spree::Admin::ResourceController
 
   before_filter :load_payment_methods
+  before_filter :load_shipping_methods
 
   private
     def load_payment_methods
       @payment_methods = Spree::PaymentMethod.all
+    end
+
+    def load_shipping_methods
+      @shipping_methods = Spree::ShippingMethod.all
     end
 end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -1,0 +1,18 @@
+Spree::ShippingMethod.class_eval do
+  has_many :store_shipping_methods
+  has_many :stores, :through => :store_shipping_methods
+
+  # This adds store_match to the list of requirements.
+  # This will need to be fixed for Spree 2.0 when split shipments is added
+  def available_to_order?(order, display_on= nil)
+    available?(order, display_on) &&
+    within_zone?(order) &&
+    category_match?(order) &&
+    currency_match?(order) &&
+    store_match?(order)
+  end
+
+  def store_match?(order)
+    order.store.shipping_methods.empty? || stores.include?(order.store)
+  end
+end

--- a/app/models/spree/store.rb
+++ b/app/models/spree/store.rb
@@ -3,11 +3,15 @@ module Spree
     has_and_belongs_to_many :products, :join_table => 'spree_products_stores'
     has_many :taxonomies
     has_many :orders
+
     has_many :store_payment_methods
     has_many :payment_methods, :through => :store_payment_methods
 
+    has_many :store_shipping_methods
+    has_many :shipping_methods, :through => :store_shipping_methods
+
     validates_presence_of :name, :code, :domains
-    attr_accessible :name, :code, :default, :email, :domains, :logo, :default_currency,  :payment_method_ids
+    attr_accessible :name, :code, :default, :email, :domains, :logo, :default_currency, :payment_method_ids, :shipping_method_ids
 
     scope :default, where(:default => true)
     scope :by_domain, lambda { |domain| where("domains like ?", "%#{domain}%") }

--- a/app/models/spree/store_shipping_method.rb
+++ b/app/models/spree/store_shipping_method.rb
@@ -1,0 +1,6 @@
+module Spree
+  class StoreShippingMethod < ActiveRecord::Base
+    belongs_to :store
+    belongs_to :shipping_method
+  end
+end

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -58,16 +58,33 @@
     <% end %>
   </div>
 
-  <div class="omega eight columns">
-    <%= f.field_container :payment_methods do %>
-      <%= f.label :payment_methods, t(:payment_methods) %><br />
-      <% @payment_methods.each do |payment_method| %>
-        <label class="sub">
-          <%= check_box_tag 'store[payment_method_ids][]', payment_method.id, @store.payment_methods.include?(payment_method) %>
-        </label> &nbsp;
-        <%= "#{payment_method.name} (#{payment_method.environment})" %>
+  <div class='row'>
+    <div class="alpha six columns">
+      <%= f.field_container :payment_methods do %>
+        <%= f.label :payment_methods, t(:payment_methods) %><br />
+        <% @payment_methods.each do |payment_method| %>
+          <label class="sub">
+            <%= check_box_tag 'store[payment_method_ids][]', payment_method.id, @store.payment_methods.include?(payment_method) %>
+          </label> &nbsp;
+          <%= "#{payment_method.name} (#{payment_method.environment})" %>
+          <br>
+        <% end %>
+        <%= hidden_field_tag 'store[payment_method_ids][]', '' %>
       <% end %>
-      <%= hidden_field_tag 'store[payment_method_ids][]', '' %>
-    <% end %>
+    </div>
+
+    <div class="omega six columns">
+      <%= f.field_container :shipping_methods do %>
+        <%= f.label :shipping_methods, t(:shipping_methods) %><br />
+        <% @shipping_methods.each do |shipping_method| %>
+          <label class="sub">
+            <%= check_box_tag 'store[shipping_method_ids][]', shipping_method.id, @store.shipping_methods.include?(shipping_method) %>
+          </label> &nbsp;
+          <%= shipping_method.name %>
+          <br>
+        <% end %>
+        <%= hidden_field_tag 'store[shipping_method_ids][]', '' %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/db/migrate/20130325231147_add_store_shipping_methods.rb
+++ b/db/migrate/20130325231147_add_store_shipping_methods.rb
@@ -1,0 +1,14 @@
+class AddStoreShippingMethods < ActiveRecord::Migration
+  def change
+    create_table :spree_store_shipping_methods do |t|
+      t.integer :store_id
+      t.integer :shipping_method_id
+
+      t.timestamps
+    end
+
+    add_index :spree_store_shipping_methods, :store_id
+    add_index :spree_store_shipping_methods, :shipping_method_id
+  end
+end
+

--- a/spec/models/spree/shipping_method_decorator_spec.rb
+++ b/spec/models/spree/shipping_method_decorator_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Spree::ShippingMethod do
+  let(:shipping_method) { create :shipping_method }
+  let(:order) { create :order, :store => store }
+  let(:store) { create :store }
+
+  describe '.store_match?' do
+    subject { shipping_method.store_match?(order) }
+
+    context 'when store contains this shipping method' do
+      before { store.shipping_methods << shipping_method }
+      it { should == true }
+    end
+
+    context "when the store does not contain this shipping method" do
+      context "when the store has no shipping methods" do
+        it { should == true }
+      end
+
+      context "when the store has at least on shipping method" do
+        before { store.shipping_methods << FactoryGirl.create(:shipping_method) }
+        it { should == false}
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,5 +33,6 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = true
 
+  config.include FactoryGirl::Syntax::Methods
   config.include Spree::Core::TestingSupport::ControllerRequests
 end

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_core', '~> 1.3.2'
 
   s.add_development_dependency 'capybara', '~> 1.0.1'
-  s.add_development_dependency 'factory_girl'
+  # This is the version used in Spree 1.3.2
+  s.add_development_dependency 'factory_girl', '~> 2.6.4'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 2.7'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
This will allow an administrator to restrict which shipping methods
are available for each store.

If shipping methods is blank, then all are available.
