### PR TITLE
Fix dynamic layout resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Current features:
 
 2. Stores and domains can be maintained via the configuration section of the Admin interface
 
-2. Each store can have it's own layout(s) - these layouts should be located in your site's theme extension in the app/views/layouts/_store#code_/ directory. So, if you have a store with
-a code of "alpha" you should store it's default layout in app/views/layouts/alpha/spree_application.html.erb
+2. Each store can have its own layout(s) - these layouts should be located in your site's theme extension in the app/views/spree/layouts/_store#code_/ directory. So, if you have a store with
+a code of "alpha" you should store its default layout in app/views/spree/layouts/alpha/spree_application.html.erb
 
 3. Each product can be assigned to one or more stores.
 

--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -22,8 +22,8 @@ module SpreeMultiDomain
         def find_layout_with_multi_store(layout, locals)
           store_layout = layout
 
-          if respond_to?(:current_store) && current_store && !controller.is_a?(Spree::Admin::BaseController)
-            store_layout = layout.gsub("layouts/", "layouts/#{current_store.code}/")
+          if @view.respond_to?(:current_store) && @view.current_store && !@view.controller.is_a?(Spree::Admin::BaseController)
+            store_layout = layout.call.gsub("layouts/", "layouts/#{@view.current_store.code}/")
           end
 
           begin

--- a/spec/requests/template_renderer_spec.rb
+++ b/spec/requests/template_renderer_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "Template renderer with dynamic layouts" do
+  before(:each) do
+    ApplicationController.view_paths = [ActionView::FixtureResolver.new(
+        "spree/layouts/spree_application.html.erb"             => "Default layout <%= yield %>",
+        "spree/layouts/my_store/spree_application.html.erb"    => "Store layout <%= yield %>",
+        "application/index.html.erb"                           => "hello"
+      )]
+  end
+
+  it "should render the layout corresponding to the current store" do
+    FactoryGirl.create :store
+    
+    get "http://www.example.com"
+    response.body.should eql("Store layout hello")
+  end
+
+  it "should fall back to the default layout if none are found for the current store" do
+    get "http://www.example.com"
+    response.body.should eql("Default layout hello")
+  end
+end


### PR DESCRIPTION
- When looking for a dynamic layout, ask the view context for the current store (instead of the template renderer - fixes #39)
- Updated the readme to mention that Spree will look for templates in spree/layouts.
