### PR TITLE
Spree::Store now ensures that there always will be a default (in 2-1-stable)

### DIFF
--- a/app/models/spree/store.rb
+++ b/app/models/spree/store.rb
@@ -13,6 +13,8 @@ module Spree
     has_and_belongs_to_many :promotion_rules, :class_name => 'Spree::Promotion::Rules::Store', :join_table => 'spree_promotion_rules_stores', :association_foreign_key => 'promotion_rule_id'
 
     validates_presence_of :name, :code, :domains
+    
+    before_create :ensure_default_exists_and_is_unique
 
     scope :default, lambda { where(:default => true) }
     scope :by_domain, lambda { |domain| where("domains like ?", "%#{domain}%") }
@@ -34,6 +36,14 @@ module Spree
 
     def self.first_found_default
       @cached_default ||= Store.default.first
+    end
+
+    def ensure_default_exists_and_is_unique
+      if default and not Store.default.empty?
+        Store.update_all(default: false)
+      elsif Store.default.empty?
+        self.default = true
+      end
     end
   end
 end

--- a/spec/models/spree/store_spec.rb
+++ b/spec/models/spree/store_spec.rb
@@ -2,16 +2,32 @@ require 'spec_helper'
 
 describe Spree::Store do
 
-  before(:each) do
-    @store = FactoryGirl.create(:store, :domains => "website1.com\nwww.subdomain.com")
-    @store2 = FactoryGirl.create(:store, :domains => 'freethewhales.com')
+  describe "by_domain" do 
+    let!(:store)    { FactoryGirl.create(:store, :domains => "website1.com\nwww.subdomain.com") }
+    let!(:store_2)  { FactoryGirl.create(:store, :domains => 'freethewhales.com') }
+
+    it "should find stores by domain" do
+      by_domain = Spree::Store.by_domain('www.subdomain.com')
+
+      by_domain.should include(store)
+      by_domain.should_not include(store_2)
+    end
   end
 
-  it "should find stores by domain" do
-    by_domain = Spree::Store.by_domain('www.subdomain.com')
+  describe "default" do
+    let!(:store)    { FactoryGirl.create(:store) }
+    let!(:store_2)  { FactoryGirl.create(:store, default: true) }
 
-    by_domain.should include(@store)
-    by_domain.should_not include(@store2)
+    it "should ensure there is a default if one doesn't exist yet" do
+      store.default.should be_true
+    end
+
+    it "should ensure there is only one default" do
+      [store, store_2].each(&:reload)
+      
+      Spree::Store.default.count.should == 1
+      store_2.default.should be_true
+      store.default.should_not be_true
+    end
   end
-
 end


### PR DESCRIPTION
Spree::Store now ensures that there always will be a default (even if the developer fails to set one) and that there will be a maximum of 1

This is a dupe of the PR I made for master, we actually need it in 2-1-stable as well. 
