### PR TITLE
Ignore Case for Paperclip Filename Validation

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -19,7 +19,7 @@ module Spree
       :path => 'stores/:id/:style/:basename.:extension',
       :convert_options => { :all => '-strip -auto-orient' }
 
-    validates_attachment_file_name :logo, :matches => [/png\Z/, /jpe?g\Z/]
+    validates_attachment_file_name :logo, :matches => [/png\Z/i, /jpe?g\Z/i]
 
   end
 end


### PR DESCRIPTION
I think we should ignore the cases when checking the paperclip file name
