### PR TITLE
Update subject title. Put example for 'send mail as'

### DIFF
--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -3,7 +3,7 @@ module Spree
     def confirm_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
       mail_params = {:to => @order.email, :subject => subject}
       if @order.store.present? && @order.store.mail_from_address.present?
         mail_params[:from] = @order.store.mail_from_address
@@ -16,7 +16,7 @@ module Spree
     def cancel_email(order, resend = false)
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
       mail_params = {:to => @order.email, :subject => subject}
       if @order.store.present? && @order.store.mail_from_address.present?
         mail_params[:from] = @order.store.mail_from_address

--- a/app/mailers/spree/shipment_mailer.rb
+++ b/app/mailers/spree/shipment_mailer.rb
@@ -3,7 +3,7 @@ module Spree
     def shipped_email(shipment, resend = false)
       @shipment = shipment.respond_to?(:id) ? shipment : Spree::Shipment.find(shipment)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
-      subject += "#{Spree::Config[:site_name]} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
+      subject += "#{Spree::Store.current.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
 
       mail_params = {:to => @shipment.order.email, :subject => subject}
       if @shipment.order.store && @shipment.order.store.mail_from_address.present?

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -29,7 +29,7 @@
   <div class="four columns">
     <%= f.field_container :mail_from_address do %>
       <%= f.label :mail_from_address, Spree.t(:send_mails_as) %><br />
-      <%= f.text_field :mail_from_address, :class => 'fullwidth' %>
+      <%= f.text_field :mail_from_address, :class => 'fullwidth', :placeholder => 'support@example.com' %>
       <%= error_message_on :store, :mail_from_address %>
     <% end %>
   </div>


### PR DESCRIPTION
Updated the mailer to use same site name for subject as what Spree 2.3 is using.

Put in example of "support@example.com" as placeholder for "send mail as" field to avoid confusion as to what to put there. We had a wrong value there for a while that was causing mail to bounce from some email providers.
