### PR TITLE
Only show product if the current store matches in the api

### DIFF
--- a/app/controllers/concerns/spree_multi_domain/show_product_support.rb
+++ b/app/controllers/concerns/spree_multi_domain/show_product_support.rb
@@ -1,0 +1,17 @@
+module SpreeMultiDomain::ShowProductSupport
+  extend ActiveSupport::Concern
+
+  included do
+    prepend(InstanceMethods)
+    before_filter :can_show_product, :only => :show
+  end
+
+  module InstanceMethods
+    def can_show_product
+      @product ||= Spree::Product.friendly.find(params[:id])
+      if @product.stores.empty? || !@product.stores.include?(current_store)
+        raise ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end

--- a/app/controllers/spree/api/products_controller_decorator.rb
+++ b/app/controllers/spree/api/products_controller_decorator.rb
@@ -1,0 +1,1 @@
+Spree::Api::ProductsController.include(SpreeMultiDomain::ShowProductSupport)

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,14 +1,1 @@
-Spree::ProductsController.class_eval do
-
-  before_filter :can_show_product, :only => :show
-
-  private
-
-  def can_show_product
-    @product ||= Spree::Product.friendly.find(params[:id])
-    if @product.stores.empty? || !@product.stores.include?(current_store)
-      raise ActiveRecord::RecordNotFound
-    end
-  end
-
-end
+Spree::ProductsController.include(SpreeMultiDomain::ShowProductSupport)

--- a/spec/controllers/spree/api/products_controller_spec.rb
+++ b/spec/controllers/spree/api/products_controller_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Spree::Api::ProductsController do
+
+  let!(:product) { FactoryGirl.create(:product) }
+
+  let(:user)  { create(:user) }
+  before { allow(controller).to receive(:current_spree_user) { user } }
+
+  describe 'on :show to a product without any stores' do
+    let!(:store) { FactoryGirl.create(:store) }
+
+    it 'should return 404' do
+      spree_get :show, :id => product.to_param, format: :json
+
+      response.response_code.should == 404
+    end
+  end
+
+  # Regression test for #75
+  describe 'on :show to a product in the wrong store' do
+    let!(:store_1) { FactoryGirl.create(:store) }
+    let!(:store_2) { FactoryGirl.create(:store) }
+
+    before(:each) do
+      product.stores << store_1
+    end
+
+    it 'should return 404' do
+      controller.stub(:current_store => store_2)
+      spree_get :show, :id => product.to_param, format: :json
+
+      response.response_code.should == 404
+    end
+  end
+
+  describe 'on :show to a product w/ store' do
+    let!(:store) { FactoryGirl.create(:store) }
+
+    before(:each) do
+      product.stores << store
+    end
+
+    it 'should return 200' do
+      controller.stub(:current_store => store)
+      spree_get :show, :id => product.to_param, format: :json
+
+      response.response_code.should == 200
+    end
+  end
+
+end


### PR DESCRIPTION
We currently do this in the products controller for frontend, but not in the api. This makes sure we're not showing products for different stores through the ProductsController in the api.
