### PR TITLE
3 0 stable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-branch = '2-4-stable'
+branch = '3-0-stable'
 
 gem 'spree', github: 'spree/spree', branch: branch
 gem 'spree_multi_currency', github: 'spree/spree_multi_currency', branch: branch

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -4,8 +4,8 @@ Spree::PaymentMethod.class_eval do
 
   def self.available(display_on = 'both', store = nil)
     result = all.select do |p|
+      # (p.environment == Rails.env || p.environment.blank?) &&
       p.active &&
-        (p.environment == Rails.env || p.environment.blank?) &&
         (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)) &&
         (p.display_on == display_on.to_s || p.display_on.blank?)
     end

--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -2,6 +2,7 @@ Spree::Tracker.class_eval do
   belongs_to :store
 
   def self.current(domain)
-    Spree::Tracker.where(:active => true, :environment => Rails.env).joins(:store).where("spree_stores.url LIKE ?", "%#{domain}%").first
+    # , :environment => Rails.env
+    Spree::Tracker.where(:active => true).joins(:store).where("spree_stores.url LIKE ?", "%#{domain}%").first
   end
 end

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -66,7 +66,8 @@
           <label class="sub">
             <%= check_box_tag 'store[payment_method_ids][]', payment_method.id, @store.payment_methods.include?(payment_method) %>
           </label> &nbsp;
-          <%= "#{payment_method.name} (#{payment_method.environment})" %>
+          <!-- "#{payment_method.name} (#{payment_method.environment})" -->
+          <%= payment_method.name %>
           <br>
         <% end %>
         <%= hidden_field_tag 'store[payment_method_ids][]', '' %>

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -2,10 +2,10 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_multi_domain'
-  s.version     = '1.0.0'
+  s.version     = '3.0.0'
   s.summary     = 'Adds multiple site support to Spree'
   s.description = 'Multiple Spree stores on different domains - single unified backed for processing orders.'
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9.2'
 
   s.authors           = ['Brian Quinn', 'Roman Smirnov', 'David North']
   s.email             = 'brian@railsdog.com'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  version = '~> 2.4.0.beta'
+  version = '~> 3.0.0'
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_backend', version
   s.add_dependency 'spree_frontend', version


### PR DESCRIPTION
With the release of spree-3-0-stable, this gem no longer works. I have updated just the necessary files so as it doesn't fail:
* Change ruby minimum required version from 1.8.7 to 1.9.2
* Change spree required version from 2.4 to 3.0
* Remove all references to "environment" attribute in spree_trackers as it has been deprecated (https://guides.spreecommerce.com/release_notes/spree_3_0_0.html)