### PR TITLE
Tested the gem inside spree 3.1.0.beta and updated the gemspec

### DIFF
--- a/app/overrides/decorate_admin_orders_index.rb
+++ b/app/overrides/decorate_admin_orders_index.rb
@@ -1,0 +1,8 @@
+
+
+Deface::Override.new(
+    :virtual_path => "spree/admin/orders/index",
+    :name => "add_filter_for_store_to_order_index",
+    :insert_before => "[data-hook='admin_orders_index_search_buttons']",
+    :partial => "spree/admin/orders/store_filter",
+    :disabled => false)

--- a/app/overrides/decorate_admin_taxonomies_list.rb
+++ b/app/overrides/decorate_admin_taxonomies_list.rb
@@ -1,14 +1,14 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/taxonomies/_list",
-  :name => "multi_domain_admin_taxonomies_list_head",
-  :insert_before => "th.actions",
-  :text => "<th><%= Spree.t(:store) %></th>",
-  :disabled => false)
+    :virtual_path => "spree/admin/taxonomies/_list",
+    :name => "multi_domain_admin_taxonomies_list_head",
+    :insert_before => "th.actions",
+    :text => "<th><%= Spree.t(:store) %></th>",
+    :disabled => false)
 
 
 Deface::Override.new(
-  :virtual_path => "spree/admin/taxonomies/_list",
-  :name => "multi_domain_admin_taxonomies_list_body",
-  :insert_before => "td.actions",
-  :text => "<td><%= taxonomy.store.try(:name) %></td>",
-  :disabled => false)
+    :virtual_path => "spree/admin/taxonomies/_list",
+    :name => "multi_domain_admin_taxonomies_list_body",
+    :insert_before => "td.actions",
+    :text => "<td><%= taxonomy.store.try(:name) %></td>",
+    :disabled => false)

--- a/app/views/spree/admin/orders/_store_filter.html.erb
+++ b/app/views/spree/admin/orders/_store_filter.html.erb
@@ -1,0 +1,8 @@
+<div class="row">
+  <div class="col-md-4">
+    <div class="form-group">
+      <%= label_tag :q_store_id_eq, Spree.t(:stores) %>
+      <%= f.select :store_id_eq, options_from_collection_for_select(Spree::Store.all, 'id', 'name', f.object.store_id_eq), {include_blank: true}, {class: 'select2'} %>
+    </div>
+  </div>
+</div>

--- a/app/views/spree/admin/orders/_store_filter.html.erb
+++ b/app/views/spree/admin/orders/_store_filter.html.erb
@@ -1,4 +1,4 @@
-<div class="row">
+<div class="row" data-hook="multidomain_first_additional_order_search_filter_row">
   <div class="col-md-4">
     <div class="form-group">
       <%= label_tag :q_store_id_eq, Spree.t(:stores) %>

--- a/app/views/spree/admin/products/_stores.html.erb
+++ b/app/views/spree/admin/products/_stores.html.erb
@@ -1,6 +1,4 @@
 <p data-hook="admin_product_form_stores" class="omega two columns">
   <%= f.label :stores, Spree.t(:stores)%><br />
-  <% Spree::Store.all.each do |store| %>
-    <%= check_box_tag "product[store_ids][]", store.id, @product.stores.include?(store) %> <%= store.name %>
-  <% end %>
+  <%= f.select :store_ids, options_from_collection_for_select(Spree::Store.all, 'id', 'name', f.object.store_ids), {}, {multiple: true, class: 'select2'} %>
 </p>

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  version = '~> 3.0.0'
+  version = '~> 3.1.0.beta'
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_backend', version
   s.add_dependency 'spree_frontend', version


### PR DESCRIPTION
The multi domain gem could not be installed since the dependencies were not matching with the versions  in spree 3.1.0.beta 
I installed it, tested it and updated it. 
Also improved the look of the store select in the product form in admin.