### PR TITLE
refactor code to have new hash syntax and other minor changes, add by…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-branch = '3-0-stable'
+branch = 'master'
 
 gem 'spree', github: 'spree/spree', branch: branch
 gem 'spree_multi_currency', github: 'spree/spree_multi_currency', branch: branch

--- a/app/controllers/spree/products_controller_decorator.rb
+++ b/app/controllers/spree/products_controller_decorator.rb
@@ -1,6 +1,6 @@
 Spree::ProductsController.class_eval do
 
-  before_filter :can_show_product, :only => :show
+  before_filter :can_show_product, only: :show
 
   private
 

--- a/app/controllers/spree/taxons_controller_decorator.rb
+++ b/app/controllers/spree/taxons_controller_decorator.rb
@@ -3,7 +3,7 @@ Spree::TaxonsController.class_eval do
     @taxon = Spree::Taxon.find_by_store_id_and_permalink!(current_store.id, params[:id])
     return unless @taxon
 
-    @searcher = build_searcher(params.merge(:taxon => @taxon.id))
+    @searcher = build_searcher(params.merge(taxon: @taxon.id))
     @products = @searcher.retrieve_products
     @taxonomies = get_taxonomies
   end

--- a/app/helpers/spree/products_helper_decorator.rb
+++ b/app/helpers/spree/products_helper_decorator.rb
@@ -2,8 +2,8 @@ module Spree
   module Api
     ProductsHelper.class_eval do
       def get_taxonomies
-        @taxonomies ||= current_store.present? ? Spree::Taxonomy.where(["store_id = ?", current_store.id]) : Spree::Taxonomy
-        @taxonomies = @taxonomies.includes(:root => :children)
+        @taxonomies ||= current_store.present? ? Spree::Taxonomy.by_store(current_store) : Spree::Taxonomy
+        @taxonomies = @taxonomies.includes(root: :children)
         @taxonomies
       end
     end

--- a/app/mailers/spree/order_mailer.rb
+++ b/app/mailers/spree/order_mailer.rb
@@ -4,7 +4,7 @@ module Spree
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{@order.store.name} #{Spree.t('order_mailer.confirm_email.subject')} ##{@order.number}"
-      mail_params = {:to => @order.email, :subject => subject}
+      mail_params = {to: @order.email, subject: subject}
       if @order.store.present? && @order.store.mail_from_address.present?
         mail_params[:from] = @order.store.mail_from_address
       else
@@ -17,7 +17,7 @@ module Spree
       @order = order.respond_to?(:id) ? order : Spree::Order.find(order)
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{@order.store.name} #{Spree.t('order_mailer.cancel_email.subject')} ##{@order.number}"
-      mail_params = {:to => @order.email, :subject => subject}
+      mail_params = {to: @order.email, subject: subject}
       if @order.store.present? && @order.store.mail_from_address.present?
         mail_params[:from] = @order.store.mail_from_address
       else

--- a/app/mailers/spree/shipment_mailer.rb
+++ b/app/mailers/spree/shipment_mailer.rb
@@ -5,7 +5,7 @@ module Spree
       subject = (resend ? "[#{Spree.t(:resend).upcase}] " : '')
       subject += "#{@shipment.order.store.name} #{Spree.t('shipment_mailer.shipped_email.subject')} ##{@shipment.order.number}"
 
-      mail_params = {:to => @shipment.order.email, :subject => subject}
+      mail_params = { to: @shipment.order.email, subject: subject }
       if @shipment.order.store && @shipment.order.store.mail_from_address.present?
         mail_params[:from] = @shipment.order.store.mail_from_address
       else

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,6 +1,6 @@
 Spree::Order.class_eval do
   belongs_to :store
-  scope :by_store, lambda { |store| where(:store_id => store.id) }
+  scope :by_store, -> (store) { where(store_id: store) }
 
   def available_payment_methods
     @available_payment_methods ||= Spree::PaymentMethod.available(:front_end, store)

--- a/app/models/spree/payment_method_decorator.rb
+++ b/app/models/spree/payment_method_decorator.rb
@@ -1,13 +1,12 @@
 Spree::PaymentMethod.class_eval do
   has_many :store_payment_methods
-  has_many :stores, :through => :store_payment_methods
+  has_many :stores, through: :store_payment_methods
 
   def self.available(display_on = 'both', store = nil)
-    result = all.select do |p|
-      # (p.environment == Rails.env || p.environment.blank?) &&
-      p.active &&
-        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(p)) &&
-        (p.display_on == display_on.to_s || p.display_on.blank?)
+    result = all.select do |payment_method|
+      payment_method.active &&
+        (store.nil? || store.payment_methods.empty? || store.payment_methods.include?(payment_method)) &&
+        (payment_method.display_on.blank? || payment_method.display_on.in?(['both', display_on.to_s]))
     end
   end
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,4 +1,4 @@
 Spree::Product.class_eval do
-  has_and_belongs_to_many :stores, :join_table => 'spree_products_stores'
-  scope :by_store, lambda { |store| joins(:stores).where("spree_products_stores.store_id = ?", store) }
+  has_and_belongs_to_many :stores, join_table: 'spree_products_stores'
+  scope :by_store, -> (store) { joins(:stores).where(spree_products_stores: { store_id: store }) }
 end

--- a/app/models/spree/shipping_method_decorator.rb
+++ b/app/models/spree/shipping_method_decorator.rb
@@ -1,6 +1,6 @@
 Spree::ShippingMethod.class_eval do
   has_many :store_shipping_methods
-  has_many :stores, :through => :store_shipping_methods
+  has_many :stores, through: :store_shipping_methods
 
   # This adds store_match to the list of requirements.
   # This will need to be fixed for Spree 2.0 when split shipments is added

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,26 +1,26 @@
 module Spree
   Store.class_eval do
-    has_and_belongs_to_many :products, :join_table => 'spree_products_stores'
+    has_and_belongs_to_many :products, join_table: 'spree_products_stores'
     has_many :taxonomies
     has_many :orders
 
     has_many :store_payment_methods
-    has_many :payment_methods, :through => :store_payment_methods
+    has_many :payment_methods, through: :store_payment_methods
 
     has_many :store_shipping_methods
-    has_many :shipping_methods, :through => :store_shipping_methods
+    has_many :shipping_methods, through: :store_shipping_methods
 
-    has_and_belongs_to_many :promotion_rules, :class_name => 'Spree::Promotion::Rules::Store', :join_table => 'spree_promotion_rules_stores', :association_foreign_key => 'promotion_rule_id'
+    has_and_belongs_to_many :promotion_rules, class_name: 'Spree::Promotion::Rules::Store', join_table: 'spree_promotion_rules_stores', association_foreign_key: 'promotion_rule_id'
 
     has_attached_file :logo,
-      :styles => { :mini => '48x48>', :small => '100x100>', :medium => '250x250>' },
-      :default_style => :medium,
-      :url => 'stores/:id/:style/:basename.:extension',
-      :path => 'stores/:id/:style/:basename.:extension',
-      :convert_options => { :all => '-strip -auto-orient' }
+      styles: { mini: '48x48>', small: '100x100>', medium: '250x250>' },
+      default_style: :medium,
+      url: 'stores/:id/:style/:basename.:extension',
+      path: 'stores/:id/:style/:basename.:extension',
+      convert_options: { all: '-strip -auto-orient' }
 
     if respond_to? :logo_file_name
-      validates_attachment_file_name :logo, :matches => [/png\Z/i, /jpe?g\Z/i]
+      validates_attachment_file_name :logo, matches: [/png\Z/i, /jpe?g\Z/i]
     end
 
   end

--- a/app/models/spree/taxon_decorator.rb
+++ b/app/models/spree/taxon_decorator.rb
@@ -1,5 +1,7 @@
 Spree::Taxon.class_eval do
+  scope :by_store, -> (store) { joins(:taxonomy).merge(Spree::Taxonomy.by_store(store)) }
+
   def self.find_by_store_id_and_permalink!(store_id, permalink)
-    joins(:taxonomy).where("spree_taxonomies.store_id = ?", store_id).where(permalink: permalink).first!    
+    by_store(store_id).where(permalink: permalink).first!
   end
 end

--- a/app/models/spree/taxonomy_decorator.rb
+++ b/app/models/spree/taxonomy_decorator.rb
@@ -1,3 +1,5 @@
 Spree::Taxonomy.class_eval do
   belongs_to :store
+
+  scope :by_store, -> (store) { where(store_id: store) }
 end

--- a/app/overrides/decorate_admin_products_form.rb
+++ b/app/overrides/decorate_admin_products_form.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/products/_form",
-  :name => "multi_domain_admin_product_form_meta",
-  :insert_bottom => "[data-hook='admin_product_form_meta']",
-  :partial => "spree/admin/products/stores",
-  :disabled => false)
+  virtual_path: "spree/admin/products/_form",
+  name: "multi_domain_admin_product_form_meta",
+  insert_bottom: "[data-hook='admin_product_form_meta']",
+  partial: "spree/admin/products/stores",
+  disabled: false)

--- a/app/overrides/decorate_admin_products_index.rb
+++ b/app/overrides/decorate_admin_products_index.rb
@@ -1,20 +1,20 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/products/index",
-  :name => "multi_domain_admin_products_index_headers",
-  :insert_before => "[data-hook='admin_products_index_header_actions']",
-  :partial => "spree/admin/products/index_headers",
-  :disabled => false)
+  virtual_path: "spree/admin/products/index",
+  name: "multi_domain_admin_products_index_headers",
+  insert_before: "[data-hook='admin_products_index_header_actions']",
+  partial: "spree/admin/products/index_headers",
+  disabled: false)
 
 Deface::Override.new(
-  :virtual_path => "spree/admin/products/index",
-  :name => "multi_domain_admin_products_index_rows",
-  :insert_before => "[data-hook='admin_products_index_row_actions']",
-  :partial => "spree/admin/products/index_rows",
-  :disabled => false)
+  virtual_path: "spree/admin/products/index",
+  name: "multi_domain_admin_products_index_rows",
+  insert_before: "[data-hook='admin_products_index_row_actions']",
+  partial: "spree/admin/products/index_rows",
+  disabled: false)
 
 Deface::Override.new(
-  :virtual_path => "spree/admin/products/index",
-  :name => "multi_domain_admin_products_index_search",
-  :insert_top => "[data-hook='admin_products_index_search']",
-  :partial => "spree/admin/products/index_search_fields",
-  :disabled => false)
+  virtual_path: "spree/admin/products/index",
+  name: "multi_domain_admin_products_index_search",
+  insert_top: "[data-hook='admin_products_index_search']",
+  partial: "spree/admin/products/index_search_fields",
+  disabled: false)

--- a/app/overrides/decorate_admin_taxonomies_form.rb
+++ b/app/overrides/decorate_admin_taxonomies_form.rb
@@ -1,6 +1,6 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/taxonomies/_form",
-  :name => "multi_domain_admin_taxonomies_form_store_id",
-  :insert_bottom => "[data-hook='admin_inside_taxonomy_form']",
-  :partial => "spree/admin/taxonomies/store",
-  :disabled => false)
+  virtual_path: "spree/admin/taxonomies/_form",
+  name: "multi_domain_admin_taxonomies_form_store_id",
+  insert_bottom: "[data-hook='admin_inside_taxonomy_form']",
+  partial: "spree/admin/taxonomies/store",
+  disabled: false)

--- a/app/overrides/decorate_admin_taxonomies_list.rb
+++ b/app/overrides/decorate_admin_taxonomies_list.rb
@@ -1,14 +1,14 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/taxonomies/_list",
-  :name => "multi_domain_admin_taxonomies_list_head",
-  :insert_before => "th.actions",
-  :text => "<th><%= Spree.t(:store) %></th>",
-  :disabled => false)
+  virtual_path: "spree/admin/taxonomies/_list",
+  name: "multi_domain_admin_taxonomies_list_head",
+  insert_before: "th.actions",
+  text: "<th><%= Spree.t(:store) %></th>",
+  disabled: false)
 
 
 Deface::Override.new(
-  :virtual_path => "spree/admin/taxonomies/_list",
-  :name => "multi_domain_admin_taxonomies_list_body",
-  :insert_before => "td.actions",
-  :text => "<td><%= taxonomy.store.try(:name) %></td>",
-  :disabled => false)
+  virtual_path: "spree/admin/taxonomies/_list",
+  name: "multi_domain_admin_taxonomies_list_body",
+  insert_before: "td.actions",
+  text: "<td><%= taxonomy.store.try(:name) %></td>",
+  disabled: false)

--- a/app/overrides/decorate_admin_trackers_form.rb
+++ b/app/overrides/decorate_admin_trackers_form.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/trackers/_form",
-  :name => "multi_domain_additional_tracker_fields",
-  :insert_bottom => "[data-hook='additional_tracker_fields']",
-  :partial => "spree/admin/trackers/store")
+  virtual_path: "spree/admin/trackers/_form",
+  name: "multi_domain_additional_tracker_fields",
+  insert_bottom: "[data-hook='additional_tracker_fields']",
+  partial: "spree/admin/trackers/store")

--- a/app/overrides/decorate_admin_trackers_index.rb
+++ b/app/overrides/decorate_admin_trackers_index.rb
@@ -1,13 +1,13 @@
 Deface::Override.new(
-  :virtual_path => "spree/admin/trackers/index",
-  :name => "multi_domain_admin_trackers_index_headers",
-  :insert_before => "[data-hook='admin_trackers_index_headers'] th:last",
-  :text => "<th><%= I18n.t(:store) %></th>",
-  :disabled => false)
+  virtual_path: "spree/admin/trackers/index",
+  name: "multi_domain_admin_trackers_index_headers",
+  insert_before: "[data-hook='admin_trackers_index_headers'] th:last",
+  text: "<th><%= I18n.t(:store) %></th>",
+  disabled: false)
 
 Deface::Override.new(
-  :virtual_path => "spree/admin/trackers/index",
-  :name => "multi_domain_admin_trackers_index_rows",
-  :insert_before => "[data-hook='admin_trackers_index_rows'] td:last",
-  :partial => "spree/admin/trackers/index_rows",
-  :disabled => false)
+  virtual_path: "spree/admin/trackers/index",
+  name: "multi_domain_admin_trackers_index_rows",
+  insert_before: "[data-hook='admin_trackers_index_rows'] td:last",
+  partial: "spree/admin/trackers/index_rows",
+  disabled: false)

--- a/app/views/spree/admin/products/_index_search_fields.html.erb
+++ b/app/views/spree/admin/products/_index_search_fields.html.erb
@@ -1,4 +1,4 @@
 <p>
   <label><%= Spree.t(:store) %></label><br />
-  <%= f.select :stores_id_eq, Spree::Store.all.collect {|s| [s.name, s.id ] }, {:include_blank => true} %></p>
+  <%= f.select :stores_id_eq, Spree::Store.all.collect {|s| [s.name, s.id ] }, {include_blank: true} %></p>
 </p>

--- a/app/views/spree/admin/promotions/rules/_store.html.erb
+++ b/app/views/spree/admin/promotions/rules/_store.html.erb
@@ -3,6 +3,6 @@
   <input type='hidden' name='<%= param_prefix %>[store_ids_string]' class='store_picker fullwidth' value='<%= promotion_rule.store_ids.join(",") %>'>
 </div>
 <script>
-  Spree.routes.store_search = '<%= spree.admin_stores_path(:format => :json) %>';
+  Spree.routes.store_search = '<%= spree.admin_stores_path(format: :json) %>';
   $('.store_picker').storeAutocomplete();
 </script>

--- a/app/views/spree/admin/stores/_form.html.erb
+++ b/app/views/spree/admin/stores/_form.html.erb
@@ -5,7 +5,7 @@
       <div data-hook="name">
         <%= f.field_container :name, class: ['form-group'] do %>
           <%= f.label :name, Spree.t(:store_name) %><br />
-          <%= f.text_field :name, :class => 'form-control' %>
+          <%= f.text_field :name, class: 'form-control' %>
           <%= error_message_on :store, :name %>
         <% end %>
       </div>
@@ -13,7 +13,7 @@
       <div data-hook="code">
         <%= f.field_container :code, class: ['form-group'] do %>
           <%= f.label :code, Spree.t(:store_code) %><br />
-          <%= f.text_field :code, :class => 'form-control' %>
+          <%= f.text_field :code, class: 'form-control' %>
           <%= error_message_on :store, :code %>
         <% end %>
       </div>
@@ -36,7 +36,7 @@
       <div data-hook="mail_form_address">
         <%= f.field_container :mail_from_address, class: ['form-group'] do %>
           <%= f.label :mail_from_address, Spree.t(:send_mails_as) %><br />
-          <%= f.text_field :mail_from_address, :class => 'form-control' %>
+          <%= f.text_field :mail_from_address, class: 'form-control' %>
           <%= error_message_on :store, :mail_from_address %>
         <% end %>
       </div>
@@ -44,7 +44,7 @@
       <div data-hook="url">
         <%= f.field_container :url, class: ['form-group'] do %>
           <%= f.label :url, Spree.t(:domains) %><br />
-          <%= f.text_area :url, :cols => 60, :rows => 4, :class => 'form-control' %>
+          <%= f.text_area :url, cols: 60, rows: 4, class: 'form-control' %>
           <%= error_message_on :store, :url %>
         <% end %>
       </div>
@@ -92,7 +92,7 @@
       <div data-hook="default_currency">
         <%= f.field_container :default_currency, class: ['form-group'] do %>
           <%= f.label :default_currency, Spree.t(:default_currency) %>
-          <%= f.text_field :default_currency, :class => 'form-control' %>
+          <%= f.text_field :default_currency, class: 'form-control' %>
         <% end %>
       </div>
     </div>

--- a/app/views/spree/admin/stores/edit.html.erb
+++ b/app/views/spree/admin/stores/edit.html.erb
@@ -7,14 +7,14 @@
 <% end %>
 
 <div data-hook="admin_store_edit_form_header">
-  <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @store } %>
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @store } %>
 </div>
 
 <div data-hook="admin_store_edit_form">
-  <%= form_for [:admin, @store], :html => {:multipart => true} do |f| %>
+  <%= form_for [:admin, @store], html: { multipart: true } do |f| %>
     <fieldset class="no-border-top">
-      <%= render :partial => 'form', :locals => { :f => f } %>
-      <%= render :partial => 'spree/admin/shared/edit_resource_links' %>
+      <%= render partial: 'form', locals: { f: f } %>
+      <%= render partial: 'spree/admin/shared/edit_resource_links' %>
     </fieldset>
   <% end %>
 </div>

--- a/app/views/spree/admin/stores/index.html.erb
+++ b/app/views/spree/admin/stores/index.html.erb
@@ -34,8 +34,8 @@
       <td><%= store.mail_from_address %></td>
       <td><%= store.url %></td>
       <td data-hook="admin_stores_index_row_actions" class="actions">
-        <%= link_to_edit store, :no_text => true %> &nbsp;
-        <%= link_to_delete store, :no_text => true %>
+        <%= link_to_edit store, no_text: true %> &nbsp;
+        <%= link_to_delete store, no_text: true %>
       </td>
     </tr>
   <% end %>

--- a/app/views/spree/admin/stores/new.html.erb
+++ b/app/views/spree/admin/stores/new.html.erb
@@ -7,14 +7,14 @@
 <% end %>
 
 <div data-hook="admin_store_new_form_header">
-  <%= render :partial => 'spree/shared/error_messages', :locals => { :target => @store } %>
+  <%= render partial: 'spree/shared/error_messages', locals: { target: @store } %>
 </div>
 
 <div data-hook="admin_store_new_form">
-  <%= form_for [:admin, @store], :html => {:multipart => true}  do |f| %>
+  <%= form_for [:admin, @store], html: {multipart: true}  do |f| %>
     <fieldset class="no-border-top">
-      <%= render :partial => 'form', :locals => { :f => f } %>
-      <%= render :partial => 'spree/admin/shared/new_resource_links' %>
+      <%= render partial: 'form', locals: { f: f } %>
+      <%= render partial: 'spree/admin/shared/new_resource_links' %>
     </fieldset>
   <% end %>
 </div>

--- a/app/views/spree/admin/trackers/_index_rows.html.erb
+++ b/app/views/spree/admin/trackers/_index_rows.html.erb
@@ -1,1 +1,1 @@
-<td><%=tracker.store.name %></td>
+<td><%= tracker.store.name %></td>

--- a/app/views/spree/products/_taxons.html.erb
+++ b/app/views/spree/products/_taxons.html.erb
@@ -1,0 +1,12 @@
+<% if !(product_taxons_by_store = @product.taxons.by_store(current_store)).blank? %>
+  <div id="taxon-crumbs" data-hook class=" five ">
+    <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
+    <div data-hook="product_taxons">
+      <ul class="list-group" id="similar_items_by_taxon" data-hook>
+        <% product_taxons_by_store.each do |taxon| %>
+          <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/spree/products/_taxons.html.erb
+++ b/app/views/spree/products/_taxons.html.erb
@@ -1,12 +1,8 @@
-<% if !(product_taxons_by_store = @product.taxons.by_store(current_store)).blank? %>
-  <div id="taxon-crumbs" data-hook class=" five ">
-    <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
-    <div data-hook="product_taxons">
-      <ul class="list-group" id="similar_items_by_taxon" data-hook>
-        <% product_taxons_by_store.each do |taxon| %>
-          <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
-        <% end %>
-      </ul>
-    </div>
-  </div>
+<% if (product_taxons_by_store = @product.taxons.by_store(current_store)).present? %>
+  <h3 class="product-section-title"><%= Spree.t(:look_for_similar_items) %></h3>
+  <ul class="list-group" id="similar_items_by_taxon" data-hook>
+    <% product_taxons_by_store.each do |taxon| %>
+      <li class="list-group-item"><%= link_to taxon.name, seo_url(taxon) %></li>
+    <% end %>
+  </ul>
 <% end %>

--- a/db/migrate/20100227180338_create_products_stores.rb
+++ b/db/migrate/20100227180338_create_products_stores.rb
@@ -3,7 +3,7 @@ class CreateProductsStores < ActiveRecord::Migration
     create_table :products_stores, :id => false do |t|
       t.references :product
       t.references :store
-      t.timestamps
+      t.timestamps null: false
     end
   end
 

--- a/db/migrate/20110601125650_remove_datetime_columns_from_products_stores.rb
+++ b/db/migrate/20110601125650_remove_datetime_columns_from_products_stores.rb
@@ -7,7 +7,7 @@ class RemoveDatetimeColumnsFromProductsStores < ActiveRecord::Migration
 
   def self.down
     change_table :products_stores do |t|
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20121210224018_add_store_payment_methods.rb
+++ b/db/migrate/20121210224018_add_store_payment_methods.rb
@@ -4,7 +4,7 @@ class AddStorePaymentMethods < ActiveRecord::Migration
       t.integer :store_id
       t.integer :payment_method_id
 
-      t.timestamps
+      t.timestamps null: false
     end
   end
 end

--- a/db/migrate/20130325231147_add_store_shipping_methods.rb
+++ b/db/migrate/20130325231147_add_store_shipping_methods.rb
@@ -4,7 +4,7 @@ class AddStoreShippingMethods < ActiveRecord::Migration
       t.integer :store_id
       t.integer :shipping_method_id
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :spree_store_shipping_methods, :store_id

--- a/lib/spree_multi_domain/multi_domain_helpers.rb
+++ b/lib/spree_multi_domain/multi_domain_helpers.rb
@@ -14,8 +14,8 @@ module SpreeMultiDomain
     end
 
     def get_taxonomies
-      @taxonomies ||= current_store.present? ? Spree::Taxonomy.where(["store_id = ?", current_store.id]) : Spree::Taxonomy
-      @taxonomies = @taxonomies.includes(:root => :children)
+      @taxonomies ||= current_store.present? ? Spree::Taxonomy.by_store(current_store) : Spree::Taxonomy
+      @taxonomies = @taxonomies.includes(root: :children)
       @taxonomies
     end
 

--- a/spec/controllers/spree/admin/products_controller_spec.rb
+++ b/spec/controllers/spree/admin/products_controller_spec.rb
@@ -20,8 +20,8 @@ describe Spree::Admin::ProductsController do
       it "clears stores if they previously existed" do
         @product.stores << @store
 
-        spree_put :update, :id => @product.to_param,
-                      :product => {:name => @product.name}
+        spree_put :update, id: @product.to_param,
+                      product: {name: @product.name}
 
         @product.reload.store_ids.should be_empty
       end
@@ -29,8 +29,8 @@ describe Spree::Admin::ProductsController do
 
     describe "when a store is selected" do
       it "clears stores" do
-        spree_put :update, :id => @product.to_param,
-                      :product => {:name => @product.name, :store_ids => [@store.id]}
+        spree_put :update, id: @product.to_param,
+                      product: {name: @product.name, store_ids: [@store.id]}
 
         @product.reload.store_ids.should == [@store.id]
       end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'should return 404' do
-      spree_get :show, id: product.to_param, format: :json
+      spree_get :show, id: product.to_param
 
       response.response_code.should == 404
     end
@@ -25,7 +25,7 @@ describe Spree::ProductsController do
 
     it 'should return 404' do
       controller.stub(current_store: store_2)
-      spree_get :show, id: product.to_param, format: :json
+      spree_get :show, id: product.to_param
 
       response.response_code.should == 404
     end

--- a/spec/controllers/spree/products_controller_spec.rb
+++ b/spec/controllers/spree/products_controller_spec.rb
@@ -8,7 +8,7 @@ describe Spree::ProductsController do
     let!(:store) { FactoryGirl.create(:store) }
 
     it 'should return 404' do
-      spree_get :show, :id => product.to_param
+      spree_get :show, id: product.to_param, format: :json
 
       response.response_code.should == 404
     end
@@ -24,8 +24,8 @@ describe Spree::ProductsController do
     end
 
     it 'should return 404' do
-      controller.stub(:current_store => store_2)
-      spree_get :show, :id => product.to_param
+      controller.stub(current_store: store_2)
+      spree_get :show, id: product.to_param, format: :json
 
       response.response_code.should == 404
     end
@@ -39,8 +39,8 @@ describe Spree::ProductsController do
     end
 
     it 'should return 200' do
-      controller.stub(:current_store => store)
-      spree_get :show, :id => product.to_param
+      controller.stub(current_store: store)
+      spree_get :show, id: product.to_param
 
       response.response_code.should == 200
     end

--- a/spec/helpers/products_helper_decorator_spec.rb
+++ b/spec/helpers/products_helper_decorator_spec.rb
@@ -4,7 +4,7 @@ module Spree
   describe ProductsHelper do
     before(:each) do
       @store     = FactoryGirl.create(:store)
-      @taxonomy  = FactoryGirl.create(:taxonomy, :store => @store)
+      @taxonomy  = FactoryGirl.create(:taxonomy, store: @store)
       @taxonomy2 = FactoryGirl.create(:taxonomy)
 
       helper.stub(:current_store) { @store }

--- a/spec/models/spree/order_spec.rb
+++ b/spec/models/spree/order_spec.rb
@@ -4,15 +4,15 @@ describe Spree::Order do
 
   before(:each) do
     @store = FactoryGirl.create(:store)
-    @order = FactoryGirl.create(:order, :store => @store)
+    @order = FactoryGirl.create(:order, store: @store)
 
     @order2 = FactoryGirl.create(:order)
   end
 
-  it 'should correctly find products by store' do
-    by_store = Spree::Order.by_store(@store)
+  it 'should correctly find order by store' do
+    order_by_store = Spree::Order.by_store(@store)
 
-    by_store.should include(@order)
-    by_store.should_not include(@order2)
+    order_by_store.should include(@order)
+    order_by_store.should_not include(@order2)
   end
 end

--- a/spec/models/spree/payment_method_spec.rb
+++ b/spec/models/spree/payment_method_spec.rb
@@ -5,7 +5,7 @@ describe 'PaymentMethod' do
     subject { Spree::PaymentMethod.available(:front_end, store) }
 
     let!(:check_payment_method) { FactoryGirl.create :check_payment_method }
-    let(:payment_method_store) { FactoryGirl.create :store, :payment_methods => [check_payment_method] }
+    let(:payment_method_store) { FactoryGirl.create :store, payment_methods: [check_payment_method] }
 
     context "when store is not specified" do
       let(:store) { nil }

--- a/spec/models/spree/product_spec.rb
+++ b/spec/models/spree/product_spec.rb
@@ -4,9 +4,9 @@ describe Spree::Product do
 
   before(:each) do
     @store = FactoryGirl.create(:store)
-    @product = FactoryGirl.create(:product, :stores => [@store])
+    @product = FactoryGirl.create(:product, stores: [@store])
 
-    @product2 = FactoryGirl.create(:product, :slug => 'something else')
+    @product2 = FactoryGirl.create(:product, slug: 'something else')
   end
 
   it 'should correctly find products by store' do

--- a/spec/models/spree/shipping_method_decorator_spec.rb
+++ b/spec/models/spree/shipping_method_decorator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Spree::ShippingMethod do
   let(:shipping_method) { create :shipping_method }
-  let(:order) { create :order, :store => store }
+  let(:order) { create :order, store: store }
   let(:store) { create :store }
 
   describe '.store_match?' do

--- a/spec/models/spree/taxon_decorator_spec.rb
+++ b/spec/models/spree/taxon_decorator_spec.rb
@@ -27,4 +27,22 @@ describe Spree::Taxon do
       end
     end
   end
+
+  describe 'scopes' do
+    describe '.by_store' do
+      before(:each) do
+        @store = FactoryGirl.create(:store)
+        @taxonomy = FactoryGirl.create(:taxonomy, store: @store)
+        @taxon = FactoryGirl.create(:taxon, taxonomy: @taxonomy)
+        @taxon2 = FactoryGirl.create(:taxon)
+      end
+
+      it 'correctly finds taxon by store' do
+        taxon_by_store = Spree::Taxon.by_store(@store)
+
+        taxon_by_store.should include(@taxon)
+        taxon_by_store.should_not include(@taxon2)
+      end
+    end
+  end
 end

--- a/spec/models/spree/taxonomy_decorator_spec.rb
+++ b/spec/models/spree/taxonomy_decorator_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Spree::Taxonomy do
+
+  before(:each) do
+    @store = FactoryGirl.create(:store)
+    @taxonomy = FactoryGirl.create(:taxonomy, store: @store)
+
+    @taxonomy2 = FactoryGirl.create(:taxonomy)
+  end
+
+  it 'correctly finds taxonomy by store' do
+    taxonomy_by_store = Spree::Taxonomy.by_store(@store)
+
+    taxonomy_by_store.should include(@taxonomy)
+    taxonomy_by_store.should_not include(@taxonomy2)
+  end
+end

--- a/spec/models/spree/tracker_spec.rb
+++ b/spec/models/spree/tracker_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe Spree::Tracker do
   before(:each) do
     store = FactoryGirl.create(:store)
-    @tracker = FactoryGirl.create(:tracker, :store => store)
+    @tracker = FactoryGirl.create(:tracker, store: store, analytics_id: 'test-analytic-id-1')
 
-    another_store = FactoryGirl.create(:store, :url => 'completely-different-store.com')
-    @tracker2 = FactoryGirl.create(:tracker, :store => another_store)
+    another_store = FactoryGirl.create(:store, url: 'completely-different-store.com')
+    @tracker2 = FactoryGirl.create(:tracker, store: another_store, analytics_id: 'test-analytic-id-2')
   end
 
   it "should pull out the current tracker" do

--- a/spec/requests/global_controller_helpers_spec.rb
+++ b/spec/requests/global_controller_helpers_spec.rb
@@ -5,7 +5,7 @@ describe "Global controller helpers" do
   let!(:store) { FactoryGirl.create :store }
 
   before(:each) do
-    @tracker = FactoryGirl.create :tracker, :store => store
+    @tracker = FactoryGirl.create :tracker, store: store
     get '/'
   end
 
@@ -29,13 +29,13 @@ describe "Global controller helpers" do
     end
 
     context "when the current store default_currency empty" do
-      let!(:store) { FactoryGirl.create :store, :default_currency => '' }
+      let!(:store) { FactoryGirl.create :store, default_currency: '' }
 
       it { should == 'USD' }
     end
 
     context "when the current store default_currency is a currency" do
-      let!(:store) { FactoryGirl.create :store, :default_currency => 'EUR' }
+      let!(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
       it { should == 'EUR' }
     end
 
@@ -48,7 +48,7 @@ describe "Global controller helpers" do
       let!(:aud) { ::Money::Currency.find('AUD') }
       let!(:eur) { ::Money::Currency.find('EUR') }
       let!(:usd) { ::Money::Currency.find('USD') }
-      let!(:store) { FactoryGirl.create :store, :default_currency => 'EUR' }
+      let!(:store) { FactoryGirl.create :store, default_currency: 'EUR' }
 
       it 'returns supported currencies' do
         controller.stub(:supported_currencies).and_return([aud, eur, usd])

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.version     = '3.0.0'
   s.summary     = 'Adds multiple site support to Spree'
   s.description = 'Multiple Spree stores on different domains - single unified backed for processing orders.'
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 2.1.0'
 
   s.authors           = ['Brian Quinn', 'Roman Smirnov', 'David North']
   s.email             = 'brian@railsdog.com'
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
   s.add_development_dependency 'rspec-rails',  '~> 2.7'
-  s.add_development_dependency 'sass-rails', '~> 4.0.2'
-  s.add_development_dependency 'spree_multi_currency'
+  s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'sqlite3'
 end

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_multi_domain'
-  s.version     = '3.0.0'
+  s.version     = '3.1.0.beta'
   s.summary     = 'Adds multiple site support to Spree'
   s.description = 'Multiple Spree stores on different domains - single unified backed for processing orders.'
   s.required_ruby_version = '>= 2.1.0'
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  version = '~> 3.0.0'
+  version = '~> 3.1.0.beta'
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_backend', version
   s.add_dependency 'spree_frontend', version

--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -23,13 +23,13 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_frontend', version
   s.add_dependency 'spree_api', version
 
-  s.add_development_dependency 'capybara', '~> 1.1.4'
+  s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'factory_girl', '~> 4.5'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'mysql2'
   s.add_development_dependency 'pg'
-  s.add_development_dependency 'rspec-rails',  '~> 2.7'
+  s.add_development_dependency 'rspec-rails',  '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'sqlite3'
 end


### PR DESCRIPTION
…_store scope in taxonomy and taxon, fixed failing specs for spree 3.1.0.beta.
- Upgrade rspec-rails and capybara to fix https://github.com/rspec/rspec-rails/issues/1532#issuecomment-174679485, 
- add blank backend/spree_multi_domain.css file as it generates not found error while building test_app
- Remove DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`