### PR TITLE
Set spree dependencies to >= 3.1.0 and < 4.0 versions

### DIFF
--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  version = '~> 3.2.0.alpha'
+  version = '>= 3.1.0', '< 4.0'
   s.add_dependency 'spree_core', version
   s.add_dependency 'spree_backend', version
   s.add_dependency 'spree_frontend', version


### PR DESCRIPTION
This PR changes the version of spree dependencies in gemspec to point at `>= 3.1.0` and `< 4.0`.