### PR TITLE
Update to image processing for Store logos

### DIFF
--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -1,17 +1,18 @@
 Spree::Admin::ProductsController.class_eval do
   update.before :set_stores
-
-  def update
-    store_ids = params[:product][:store_ids]
-    if store_ids.present?
-      params[:product][:store_ids] = store_ids.split(',')
-    end
-    super
-  end
+  before_action :find_stores, only: [:update]
 
   private
 
   def set_stores
     @product.store_ids = nil unless params[:product].key? :store_ids
   end
+  
+  def find_stores
+    store_ids = params[:product][:store_ids]
+    if store_ids.present?
+      params[:product][:store_ids] = store_ids.split(',')
+    end
+  end
+
 end

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -11,36 +11,6 @@ module Spree
     has_many :shipping_methods, through: :store_shipping_methods
 
     has_and_belongs_to_many :promotion_rules, class_name: 'Spree::Promotion::Rules::Store', join_table: 'spree_promotion_rules_stores', association_foreign_key: 'promotion_rule_id'
-<<<<<<< HEAD
-
-    has_attached_file :logo,
-                      styles: { mini: '48x48>', small: '100x100>', logo: '250x250>', large: '600x600>' },
-                      default_style: :logo,
-                      url: '/spree/logos/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/logos/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-
-    validate :no_logo_errors
-    validates_attachment :logo,
-      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
-
-    def find_dimensions
-      temporary = logo.queued_for_write[:original]
-      filename = temporary.path unless temporary.nil?
-      filename = logo.path if filename.blank?
-      geometry = Paperclip::Geometry.from_file(filename)
-      self.logo_width  = geometry.width
-      self.logo_height = geometry.height
-    end
-
-    # if there are errors from the plugin, then add a more meaningful message
-    def no_logo_errors
-      unless logo.errors.empty?
-        # uncomment this to get rid of the less-than-useful interim messages
-        # errors.clear
-        errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
-        false
-=======
   
     if ActiveRecord::Base.connection.table_exists?(:spree_stores) && ActiveRecord::Base.connection.column_exists?(:spree_stores, :logo_content_type)
       # save the w,h of the original image (from which others can be calculated)
@@ -75,7 +45,6 @@ module Spree
           errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
           false
         end
->>>>>>> master
       end
     end
   end

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,9 +1,5 @@
 module Spree
   Store.class_eval do
-    # save the w,h of the original image (from which others can be calculated)
-    # we need to look at the write-queue for images which have not been saved yet
-    before_save :find_dimensions, if: :logo_updated_at_changed?
-
     has_and_belongs_to_many :products, join_table: 'spree_products_stores'
     has_many :taxonomies
     has_many :orders
@@ -16,34 +12,39 @@ module Spree
 
     has_and_belongs_to_many :promotion_rules, class_name: 'Spree::Promotion::Rules::Store', join_table: 'spree_promotion_rules_stores', association_foreign_key: 'promotion_rule_id'
   
-
-    has_attached_file :logo,
-                      styles: { mini: '48x48>', small: '100x100>', logo: '250x250>', large: '600x600>' },
-                      default_style: :logo,
-                      url: '/spree/logos/:id/:style/:basename.:extension',
-                      path: ':rails_root/public/spree/logos/:id/:style/:basename.:extension',
-                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
-
-    validate :no_logo_errors
-    validates_attachment :logo,
-      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
-
-    def find_dimensions
-      temporary = logo.queued_for_write[:original]
-      filename = temporary.path unless temporary.nil?
-      filename = logo.path if filename.blank?
-      geometry = Paperclip::Geometry.from_file(filename)
-      self.logo_width  = geometry.width
-      self.logo_height = geometry.height
-    end
-
-    # if there are errors from the plugin, then add a more meaningful message
-    def no_logo_errors
-      unless logo.errors.empty?
-        # uncomment this to get rid of the less-than-useful interim messages
-        # errors.clear
-        errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
-        false
+    if ActiveRecord::Base.connection.table_exists?(:spree_stores) && ActiveRecord::Base.connection.column_exists?(:spree_stores, :logo_content_type)
+      # save the w,h of the original image (from which others can be calculated)
+      # we need to look at the write-queue for images which have not been saved yet
+      before_save :find_dimensions, if: :logo_updated_at_changed?
+  
+      has_attached_file :logo,
+                        styles: { mini: '48x48>', small: '100x100>', logo: '250x250>', large: '600x600>' },
+                        default_style: :logo,
+                        url: '/spree/logos/:id/:style/:basename.:extension',
+                        path: ':rails_root/public/spree/logos/:id/:style/:basename.:extension',
+                        convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
+  
+      validate :no_logo_errors
+      validates_attachment :logo,
+        content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
+  
+      def find_dimensions
+        temporary = logo.queued_for_write[:original]
+        filename = temporary.path unless temporary.nil?
+        filename = logo.path if filename.blank?
+        geometry = Paperclip::Geometry.from_file(filename)
+        self.logo_width  = geometry.width
+        self.logo_height = geometry.height
+      end
+  
+      # if there are errors from the plugin, then add a more meaningful message
+      def no_logo_errors
+        unless logo.errors.empty?
+          # uncomment this to get rid of the less-than-useful interim messages
+          # errors.clear
+          errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
+          false
+        end
       end
     end
   end

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,5 +1,9 @@
 module Spree
   Store.class_eval do
+    # save the w,h of the original image (from which others can be calculated)
+    # we need to look at the write-queue for images which have not been saved yet
+    before_save :find_dimensions, if: :logo_updated_at_changed?
+
     has_and_belongs_to_many :products, join_table: 'spree_products_stores'
     has_many :taxonomies
     has_many :orders
@@ -11,17 +15,36 @@ module Spree
     has_many :shipping_methods, through: :store_shipping_methods
 
     has_and_belongs_to_many :promotion_rules, class_name: 'Spree::Promotion::Rules::Store', join_table: 'spree_promotion_rules_stores', association_foreign_key: 'promotion_rule_id'
+  
 
     has_attached_file :logo,
-      styles: { mini: '48x48>', small: '100x100>', medium: '250x250>' },
-      default_style: :medium,
-      url: 'stores/:id/:style/:basename.:extension',
-      path: 'stores/:id/:style/:basename.:extension',
-      convert_options: { all: '-strip -auto-orient' }
+                      styles: { mini: '48x48>', small: '100x100>', logo: '250x250>', large: '600x600>' },
+                      default_style: :logo,
+                      url: '/spree/logos/:id/:style/:basename.:extension',
+                      path: ':rails_root/public/spree/logos/:id/:style/:basename.:extension',
+                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
 
-    if respond_to? :logo_file_name
-      validates_attachment_file_name :logo, matches: [/png\Z/i, /jpe?g\Z/i]
+    validate :no_logo_errors
+    validates_attachment :logo,
+      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
+
+    def find_dimensions
+      temporary = logo.queued_for_write[:original]
+      filename = temporary.path unless temporary.nil?
+      filename = logo.path if filename.blank?
+      geometry = Paperclip::Geometry.from_file(filename)
+      self.logo_width  = geometry.width
+      self.logo_height = geometry.height
     end
 
+    # if there are errors from the plugin, then add a more meaningful message
+    def no_logo_errors
+      unless logo.errors.empty?
+        # uncomment this to get rid of the less-than-useful interim messages
+        # errors.clear
+        errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
+        false
+      end
+    end
   end
 end

--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -1,5 +1,9 @@
 module Spree
   Store.class_eval do
+    # save the w,h of the original image (from which others can be calculated)
+    # we need to look at the write-queue for images which have not been saved yet
+    before_save :find_dimensions, if: :logo_updated_at_changed?
+
     has_and_belongs_to_many :products, join_table: 'spree_products_stores'
     has_many :taxonomies
     has_many :orders
@@ -11,17 +15,36 @@ module Spree
     has_many :shipping_methods, through: :store_shipping_methods
 
     has_and_belongs_to_many :promotion_rules, class_name: 'Spree::Promotion::Rules::Store', join_table: 'spree_promotion_rules_stores', association_foreign_key: 'promotion_rule_id'
+  
+    validate :no_logo_errors
 
     has_attached_file :logo,
-      styles: { mini: '48x48>', small: '100x100>', medium: '250x250>' },
-      default_style: :medium,
-      url: 'stores/:id/:style/:basename.:extension',
-      path: 'stores/:id/:style/:basename.:extension',
-      convert_options: { all: '-strip -auto-orient' }
+                      styles: { mini: '48x48>', small: '100x100>', logo: '250x250>', large: '600x600>' },
+                      default_style: :logo,
+                      url: '/spree/logos/:id/:style/:basename.:extension',
+                      path: ':rails_root/public/spree/logos/:id/:style/:basename.:extension',
+                      convert_options: { all: '-strip -auto-orient -colorspace sRGB' }
+    validates_attachment :logo,
+      presence: true,
+      content_type: { content_type: %w(image/jpeg image/jpg image/png image/gif) }
 
-    if respond_to? :logo_file_name
-      validates_attachment_file_name :logo, matches: [/png\Z/i, /jpe?g\Z/i]
+    def find_dimensions
+      temporary = logo.queued_for_write[:original]
+      filename = temporary.path unless temporary.nil?
+      filename = logo.path if filename.blank?
+      geometry = Paperclip::Geometry.from_file(filename)
+      self.logo_width  = geometry.width
+      self.logo_height = geometry.height
     end
 
+    # if there are errors from the plugin, then add a more meaningful message
+    def no_logo_errors
+      unless logo.errors.empty?
+        # uncomment this to get rid of the less-than-useful interim messages
+        # errors.clear
+        errors.add :logo, "Paperclip returned errors for file '#{logo_file_name}' - check ImageMagick installation or image source file."
+        false
+      end
+    end
   end
 end

--- a/db/migrate/20160906012057_add_image_attributes_to_spree_stores.rb
+++ b/db/migrate/20160906012057_add_image_attributes_to_spree_stores.rb
@@ -1,0 +1,9 @@
+class AddImageAttributesToSpreeStores < ActiveRecord::Migration
+  def change
+    add_column :spree_stores, :logo_content_type, :string
+    add_column :spree_stores, :logo_file_size, :string
+    add_column :spree_stores, :logo_width, :string
+    add_column :spree_stores, :logo_height, :string
+    add_column :spree_stores, :logo_updated_at, :datetime
+  end
+end


### PR DESCRIPTION
Added attributes to Store logos to validate against content type.
Added attributes to Store logos to validate against file size.
Added callback to save height and width of Store logo (for anyone's styling needs).

Fix for issue #155 
