### PR TITLE
removed has_many :orders, is included in original

### DIFF
--- a/app/models/spree/store_decorator.rb
+++ b/app/models/spree/store_decorator.rb
@@ -2,8 +2,6 @@ module Spree
   Store.class_eval do
     has_and_belongs_to_many :products, join_table: 'spree_products_stores'
     has_many :taxonomies
-    has_many :orders
-
     has_many :store_payment_methods
     has_many :payment_methods, through: :store_payment_methods
 


### PR DESCRIPTION
The original Store definition model in Spree has the has_many relation with orders, check the next line

https://github.com/spree/spree/blob/master/core/app/models/spree/store.rb#L3