### PR TITLE
Add preprend view path based on current_store.code

### DIFF
--- a/app/controllers/spree/base_controller_decorator.rb
+++ b/app/controllers/spree/base_controller_decorator.rb
@@ -1,0 +1,5 @@
+Spree::BaseController.class_eval do
+
+  before_action { prepend_view_path "app/views/#{current_store.code}" }
+
+end


### PR DESCRIPTION
Hi there, I suggest a simple decorator on Spree::BaseController to preprend a specific view path for each stores, based on `current_store.code`
