### PR TITLE
In Spree 3.5 trackers were extracted to a separate extension

### DIFF
--- a/app/models/spree/tracker_decorator.rb
+++ b/app/models/spree/tracker_decorator.rb
@@ -1,7 +1,9 @@
-Spree::Tracker.class_eval do
-  belongs_to :store
+if defined?(Spree::Tracker)
+  Spree::Tracker.class_eval do
+    belongs_to :store
 
-  def self.current(domain)
-    Spree::Tracker.where(active: true).joins(:store).where("spree_stores.url LIKE ?", "%#{domain}%").first
+    def self.current(domain)
+      Spree::Tracker.where(active: true).joins(:store).where("spree_stores.url LIKE ?", "%#{domain}%").first
+    end
   end
 end


### PR DESCRIPTION
github.com/spree-contrib/spree_analytics_trackers