### PR TITLE
Added Deface as dependency

### DIFF
--- a/spree_multi_domain.gemspec
+++ b/spree_multi_domain.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spree_extension'
   s.add_dependency 'spree_analytics_trackers'
   s.add_dependency 'paperclip'
+  s.add_dependency 'deface', '~> 1.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
Since Spree 4.0 [doesn't require deface](https://github.com/spree/spree/pull/9394) we need to require it here