### PR TITLE
Do not override searcher_class if application has one set

### DIFF
--- a/lib/spree_multi_domain/engine.rb
+++ b/lib/spree_multi_domain/engine.rb
@@ -14,7 +14,7 @@ module SpreeMultiDomain
         end
       end
 
-      Spree::Config.searcher_class = Spree::Search::MultiDomain
+      Spree::Config.searcher_class ||= Spree::Search::MultiDomain
       ApplicationController.include SpreeMultiDomain::MultiDomainHelpers
     end
 


### PR DESCRIPTION
This causes problem in applications that use custom searcher, like in Envizzo project:
https://github.com/envizzo/spree-marketplace/blob/master/config/initializers/spree.rb#L21