### PR TITLE
fix/store-promo-rule-has-two-arguments-in-spree-now

### DIFF
--- a/app/models/spree/promotion/rules/store.rb
+++ b/app/models/spree/promotion/rules/store.rb
@@ -4,7 +4,7 @@ module Spree
       class Store < PromotionRule
         has_and_belongs_to_many :stores, class_name: 'Spree::Store', join_table: 'spree_promotion_rules_stores', foreign_key: 'promotion_rule_id'
 
-        def eligible?(order)
+        def eligible?(order, options = {})
           stores.none? or stores.include?(order.store)
         end
 

--- a/spec/models/spree/promotion/rules/store_spec.rb
+++ b/spec/models/spree/promotion/rules/store_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Spree::Promotion::Rules::Store, type: :model do
+  let(:rule) { subject }
+
+  context '#elegible?(order)' do
+    let(:order) { create :order_with_line_items }
+
+    context 'when it receives two arguments' do
+      it 'it does not raise an error' do
+        expect { rule.eligible?(order, true) }.not_to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when no stores were added' do
+      it 'is eligible' do
+        expect(rule).to be_eligible(order)
+      end
+    end
+
+    context 'when stores were added' do
+      let(:store) { create(:store, name: 'First Store') }
+      let(:store2) { create(:store, name: 'Second Store') }
+
+      before do
+        rule.stores << store << store2
+      end
+
+      context 'and order is from a different store' do
+        it 'is not eligible' do
+          expect(rule).not_to be_eligible(order)
+        end
+      end
+
+      context 'and order is from one of those stores' do
+        before do
+          order.update(store: store2)
+        end
+
+        it 'is eligible' do
+          expect(rule).to be_eligible(order)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9633679/93577913-edea6f80-f99c-11ea-883d-b0b05973698d.png)
